### PR TITLE
Fix: add jsconfig.json to fix build error

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "14.2.3",
+    "next": "14.2.29",
     "react": "^18",
     "react-dom": "^18",
     "@vercel/blob": "^0.23.0",


### PR DESCRIPTION
修复构建错误：缺少 `jsconfig.json` 导致 `@/lib/auth` 和 `@/lib/storage` 路径无法解析。

- 添加 `jsconfig.json` 配置 `@/` 路径别名
- 升级 Next.js 到 14.2.29（修复安全漏洞）

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5tX7n9ELAeXkAyJbo7xRm)_